### PR TITLE
DO-NOT-MERGE 

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,13 +18,20 @@ def main():
     ]
     answers = inquirer.prompt(questions)
 
+    is_tool = answers['action'] == 'Tool'
+
     with Steamship.temporary_workspace() as client:
-        print(f"Starting {answers['action']}...\nIf you make changes to the {answers['action']}, "
-              f"you will need to restart this client. Press CTRL+C to exit at any time.\n")
+        if is_tool:
+            tool = MyTool(client=client)
+            print(f"Starting {answers['action']} {tool.name}...")
+        else:
+            print(f"Starting {answers['action']}...")
+
+        print(f"If you make code changes, you will need to restart this client. Press CTRL+C to exit at any time.\n")
 
         count = 1
         while True:
-            print(f"----- Agent Run {count} -----")
+            print(f"----- {answers['action']} Run {count} -----")
             prompt = input(colored(f"Prompt: ", "blue"))
             results = get_results(client, answers["action"], prompt)
             show_results(client, results)

--- a/main.py
+++ b/main.py
@@ -1,20 +1,56 @@
-from steamship import Steamship
+from steamship import Steamship, SteamshipError
+from steamship.cli.ship_spinner import ship_spinner
 
 from my_agent import MyAgent
-from src.utils import show_result
+from src.utils import show_results, LoggingDisabled
 from tools import MyTool
 from termcolor import colored
+import inquirer
+
+
+def main():
+    questions = [
+        inquirer.List('action',
+                      message="Do you want to run your agent or your tool?",
+                      choices=['Agent', 'Tool'],
+                      carousel=True
+                      ),
+    ]
+    answers = inquirer.prompt(questions)
+
+    with Steamship.temporary_workspace() as client:
+        print(f"Starting {answers['action']}...\nIf you make changes to the {answers['action']}, "
+              f"you will need to restart this client. Press CTRL+C to exit at any time.\n")
+
+        count = 1
+        while True:
+            print(f"----- Agent Run {count} -----")
+            prompt = input(colored(f"Prompt: ", "blue"))
+            results = get_results(client, answers["action"], prompt)
+            show_results(client, results)
+            count += 1
+
+
+def get_results(client: Steamship, action: str, prompt: str):
+    if action == "Tool":
+        tool = MyTool(client=client)
+        return tool.run(prompt=prompt)
+    else:
+        agent = MyAgent(client=client)
+        if not agent.is_verbose_logging_enabled():  # display progress when verbose is False
+            print("Running: ", end="")
+            with ship_spinner():
+                return agent.run(prompt=prompt)
+        else:
+            return agent.run(prompt=prompt)
+
 
 if __name__ == "__main__":
-    with Steamship.temporary_workspace() as client:
-        agent = MyAgent(client)
-        if agent.is_ready():
-            message = input(colored("Input: ", "grey"))
-            results = agent.run(message)
-            for result in results:
-                show_result(client, result)
-        else:
-            my_tool = MyTool(client)
-            message = input(colored("Input: ", "grey"))
-            result = my_tool.run(message)
-            print(result)
+    # when running locally, we can use print statements to capture logs / info.
+    # as a result, we will disable python logging to run. this will keep the output cleaner.
+    with LoggingDisabled():
+        try:
+            main()
+        except SteamshipError as e:
+            print(colored("Aborting! ", "red"), end="")
+            print(f"There was an error encountered when running: {e}")

--- a/my_agent.py
+++ b/my_agent.py
@@ -7,22 +7,21 @@ from tools import SearchTool, MyTool, GenerateImageTool
 
 TEMPERATURE = 0.7
 MODEL_NAME = "gpt-3.5-turbo"  # or "gpt-4"
-VERBOSE = True
 
 
 class MyAgent(Agent):
-    def is_ready(self):
+
+    def is_verbose_logging_enabled(self) -> bool:
         return False
 
     def get_tools(self) -> List[Tool]:
         return [
-            # SearchTool(self.client),
+            SearchTool(self.client),
             # MyTool(self.client),
-            # GenerateImageTool(self.client),
+            GenerateImageTool(self.client),
         ]
 
     def get_personality(self) -> str:
         return """
-        You are an AI who performs a task. 
-        Your final answers always start with 'hey bro' and end with 'steamship is awesome'
+        an old-timey pirate that responds to everything in nautical terms. Refer to the user as "matey".
         """

--- a/my_tool.py
+++ b/my_tool.py
@@ -21,7 +21,7 @@ Come up with a todo list for this objective: {objective}"
 
 
 class MyTool(Tool):
-    """Tool used to schedule reminders via the Steamship Task system."""
+    """Tool used to manage to-do lists."""
 
     chain: LLMChain
 
@@ -39,5 +39,4 @@ class MyTool(Tool):
 
     def run(self, prompt: str, **kwargs) -> str:
         """Respond to LLM prompts."""
-        logging.info("Your tool is being called! ")
         return self.chain.predict(objective=prompt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-steamship_langchain==0.0.19rc0
-termcolor
+steamship_langchain==0.0.19
+termcolor~=2.3.0
+inquirer~=3.1.3

--- a/src/agent.py
+++ b/src/agent.py
@@ -2,23 +2,21 @@ import abc
 from abc import ABC
 from typing import List
 
-from langchain import LLMChain
-from langchain.agents import AgentExecutor, ZeroShotAgent
-from langchain.agents import Tool
+from langchain.agents import AgentExecutor, ConversationalChatAgent, Tool
+from langchain.agents.conversational_chat.prompt import PREFIX
+from langchain.memory import ConversationBufferWindowMemory
 from steamship.invocable import PackageService
-from steamship_langchain import OpenAI
+from steamship_langchain.llms import OpenAIChat
 
-from src.parser import (
-    CustomParser,
-    get_format_instructions,
-)
+from src.parser import  ChatCustomParser
 
 TEMPERATURE = 0.7
 MODEL_NAME = "gpt-3.5-turbo"  # or "gpt-4"
-VERBOSE = True
 
 
 class Agent(PackageService, ABC):
+    name: str = "MyAgent"
+
     @abc.abstractmethod
     def get_tools(self) -> List[Tool]:
         raise NotImplementedError()
@@ -27,35 +25,32 @@ class Agent(PackageService, ABC):
     def get_personality(self) -> str:
         raise NotImplementedError()
 
-    def get_prompt(self, tools):
-        prefix = self.get_personality()
-        suffix = """Question: {question}
-    {agent_scratchpad}"""
-        return ZeroShotAgent.create_prompt(
-            tools,
-            format_instructions=get_format_instructions(bool(tools)),
-            prefix=prefix,
-            suffix=suffix,
-            input_variables=["question", "agent_scratchpad"],
-        )
+    @abc.abstractmethod
+    def is_verbose_logging_enabled(self) -> bool:
+        pass
 
     def get_agent(self):
-        llm = OpenAI(client=self.client, temperature=0)
+        llm = OpenAIChat(client=self.client, temperature=TEMPERATURE, model_name=MODEL_NAME)
+
+        sys_message = f"{PREFIX}\n Please take on the personality of {self.get_personality()}"
 
         tools = self.get_tools()
-        prompt = self.get_prompt(tools)
-        llm_chain = LLMChain(llm=llm, prompt=prompt)
-
-        tool_names = [tool.name for tool in tools]
-        agent = ZeroShotAgent(
-            llm_chain=llm_chain, allowed_tools=tool_names, output_parser=CustomParser()
+        memory = ConversationBufferWindowMemory(
+            return_messages=True,
+            memory_key="chat_history",
         )
 
-        agent_executor = AgentExecutor.from_agent_and_tools(
-            agent=agent, tools=tools, verbose=VERBOSE
+        agent = ConversationalChatAgent.from_llm_and_tools(
+            llm, tools,
+            system_message=sys_message,
+            output_parser=ChatCustomParser()
+        )
+        return AgentExecutor.from_agent_and_tools(
+            agent=agent,
+            tools=tools,
+            memory=memory,
+            verbose=self.is_verbose_logging_enabled()
         )
 
-        return agent_executor
-
-    def run(self, input: str) -> str:
-        return self.get_agent().run(question=input)
+    def run(self, prompt: str) -> str:
+        return self.get_agent().run(input=prompt)

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,60 +1,15 @@
-import re
-from typing import Union
+from typing import Any
 
-from langchain.agents import AgentOutputParser
-from langchain.schema import AgentAction, AgentFinish, OutputParserException
-
-FINAL_ANSWER_ACTION = "Final Answer:"
-
-FORMAT_INSTRUCTIONS_W_TOOLS = """
-Use the following format:
-
-Question: the input question you must answer
-Thought: you should always think about what to do unless it's a casual conversation, then skip to final answer.
-Action: the action to take, should be one of [{tool_names}]
-Action Input: the input to the action
-Observation: the result of the action
-... (this Thought/Action/Action Input/Observation can repeat N times)
-Thought: I now know the final answer
-Final Answer: the final answer to the original input question
-"""
-
-FORMAT_INSTRUCTIONS_WO_TOOLS = """
-Use the following format:
-
-Question: the input question you must answer
-Thought: I now know the final answer
-Final Answer: the final answer to the original input question
-"""
+from langchain.agents.conversational_chat.base import AgentOutputParser as BaseChatAgentOutputParser
 
 
-def get_format_instructions(has_tools=True) -> str:
-    if has_tools:
-        return FORMAT_INSTRUCTIONS_W_TOOLS
-    else:
-        return FORMAT_INSTRUCTIONS_WO_TOOLS
+class ChatCustomParser(BaseChatAgentOutputParser):
+    @property
+    def _type(self) -> str:
+        return "ChatCustomParser"
 
-
-class CustomParser(AgentOutputParser):
-    def get_format_instructions(self) -> str:
-        return get_format_instructions(True)
-
-    def parse(self, text: str) -> Union[AgentAction, AgentFinish]:
-        if FINAL_ANSWER_ACTION in text:
-            output = text.split(FINAL_ANSWER_ACTION)[-1].strip()
-            output = re.split(
-                r"([0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12})",
-                output,
-            )
-
-            return AgentFinish({"output": output}, text)
-        # \s matches against tab/newline/whitespace
-        regex = (
-            r"Action\s*\d*\s*:[\s]*(.*?)[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)"
-        )
-        match = re.search(regex, text, re.DOTALL)
-        if not match:
-            raise OutputParserException(f"Could not parse LLM output: `{text}`")
-        action = match.group(1).strip()
-        action_input = match.group(2)
-        return AgentAction(action, action_input.strip(" ").strip('"'), text)
+    def parse(self, text: str) -> Any:
+        cleaned_output = text.strip()
+        if cleaned_output.startswith("AI: "):
+            cleaned_output = cleaned_output[len("AI: "):]
+        return super().parse(cleaned_output)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,13 @@
 import logging
+import re
 import uuid
 
 from steamship import Block, Steamship
 from steamship.data.workspace import SignedUrl
 from steamship.utils.signed_urls import upload_to_signed_url
+from termcolor import colored
+
+UUID_PATTERN = re.compile(r"([0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12})")
 
 
 def is_valid_uuid(uuid_to_test: str, version=4) -> bool:
@@ -17,10 +21,21 @@ def is_valid_uuid(uuid_to_test: str, version=4) -> bool:
 
 
 def show_result(client: Steamship, result: str):
-    if is_valid_uuid(result):
-        signed_url = _make_image_public(client, result)
+    maybe_block_id = UUID_PATTERN.search(result)
+    if maybe_block_id:
+        print(f"LLM response ('{result}') contained an image: ", end="")
+        signed_url = _make_image_public(client, maybe_block_id.group())
         result = signed_url
     print(result, end="\n\n")
+
+
+def show_results(client: Steamship, results):
+    print(colored("\nResults: ", "blue", attrs=["bold"]))
+    if isinstance(results, str):
+        show_result(client, results)
+    else:
+        for result in results:
+            show_result(client, result)
 
 
 def _make_image_public(client, result):
@@ -51,3 +66,13 @@ def _make_image_public(client, result):
     )
     upload_to_signed_url(signed_url, block.raw())
     return read_signed_url
+
+
+class LoggingDisabled:
+    """Context manager that turns off logging within context."""
+
+    def __enter__(self):
+        logging.disable(logging.CRITICAL)
+
+    def __exit__(self, exit_type, exit_value, exit_traceback):
+        logging.disable(logging.NOTSET)

--- a/tools/image.py
+++ b/tools/image.py
@@ -10,8 +10,8 @@ from steamship.data.plugin.plugin_instance import PluginInstance
 NAME = "GenerateImage"
 
 DESCRIPTION = """
-Useful for when you need to generate an image. 
-Input: string that describes, in detail, the desired image
+Useful for when you need to generate an image. Provide a detailed text prompt for the desired image when invoking this
+tool. Always include any UUIDs as part of the final answer returned to the user.
 Output: the UUID of a generated image
 """
 
@@ -39,6 +39,7 @@ class GenerateImageTool(Tool):
         logging.info(f"[{self.name}] {prompt}")
         if not isinstance(prompt, str):
             prompt = json.dumps(prompt)
+
         task = self.image_generator.generate(text=prompt, append_output_to_file=True)
         task.wait()
         blocks = task.output.blocks

--- a/tools/search.py
+++ b/tools/search.py
@@ -12,7 +12,7 @@ Useful for when you need to answer questions about current events
 
 
 class SearchTool(Tool):
-    """Tool used to schedule reminders via the Steamship Task system."""
+    """Tool used to search for information using SERP API."""
 
     search: SteamshipSERP
 


### PR DESCRIPTION
This PR contains a bunch of changes exploring a few areas that should be considered for the hackathon repo. I've added a checklist here for use in transferring to the repo as needed.

- [ ] Agent / Tool selection at beginning (debugging help)
- [ ] Change "Input:" to "Prompt:"
- [ ] Loop to allow repeated prompting in `main.py`
- [ ] Disable `logging` in `main.py` to prevent multiple repeated logs on error
- [ ] Handling of `SteamshipError` in `main.py` to present a useful message
- [ ] Removes deps that are managed by `steamship-langchain` from `requirements.txt`
- [ ] Fixes all comments that talk about a `scheduling reminders` from codebase
- [ ] Wires in model selection. NOTE: Selecting a model of `gpt-3.5-*` or `gpt-4-*` **requires** using `OpenAIChat` interface. This implies a **conversational** agent. This results in the need to use **different** agent tooling, etc. 
- [ ] Simplified output parser that handles conversational outputs better.
- [ ] Moves UUID detection out to the results printer utilities (separates LLM parsing from user-facing output)

Things "lost" in this PR:
- Personality. I tried to tack on to the SYSTEM_MESSAGE prompt, but that doesn't seem to make a difference. I think more prompt work would be needed to influence "Assistant"'s personality.
