### PR TITLE
Add Transport for Web Client + VS Code Run Profile & Test Helper

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceRoot}/main.py",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "env": {
+        "PYTHONPATH": "${workspaceRoot}/src"
+      }
+    }
+  ]
+}

--- a/main.py
+++ b/main.py
@@ -24,20 +24,30 @@ def main():
         )
 
         count = 1
+
+        debug_web_endpoint_via_localhost = False
+
         while True:
             print(f"----- Agent Run {count} -----")
             prompt = input(colored(f"Prompt: ", "blue"))
-            results = get_results(client, answers["action"], prompt)
+            results = get_results(client, answers["action"], prompt, as_api=debug_web_endpoint_via_localhost)
             show_results(client, results)
             count += 1
 
+        
 
-def get_results(client: Steamship, action: str, prompt: str):
+def get_results(client: Steamship, action: str, prompt: str, as_api:bool=False):
     if action == "Tool":
         tool = MyTool(client=client)
         return tool.run(prompt=prompt)
     else:
         agent = MyAgent(client=client)
+        
+        # For Debugging
+        if as_api:
+            resp = agent.answer(question=prompt)
+            return resp
+
         if (
             not agent.is_verbose_logging_enabled()
         ):  # display progress when verbose is False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 steamship_langchain==0.0.20rc0
 termcolor~=2.3.0
 inquirer~=3.1.3
+steamship==2.16.4

--- a/src/core/agent/base.py
+++ b/src/core/agent/base.py
@@ -1,11 +1,14 @@
 import abc
 import logging
 from abc import ABC
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Type, Union
+from pydantic import Field
 
 from langchain.agents import Tool
 from steamship import SteamshipError, Block
-from steamship.invocable import PackageService, post
+from steamship.experimental.transports.chat import ChatMessage
+from steamship.invocable import PackageService, post, Config
+from core.comms import CommsChannels
 
 from utils import is_valid_uuid
 
@@ -26,8 +29,23 @@ def response_for_exception(e: Optional[Exception]) -> str:
     return f"An error happened while creating a response: {e}"
 
 
+class BaseAgentConfig(Config):
+    """Config object containing parameters to initialize a MyAgent instance."""
+    telegram_token: Optional[str] = Field("", description="The secret token for your Telegram bot")
+
+
 class BaseAgent(PackageService, ABC):
     name: str = "MyAgent"
+    config: BaseAgentConfig
+    comms: CommsChannels
+
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
+        return BaseAgentConfig
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.comms = CommsChannels(self.client, telegram_token=self.config.telegram_token)
 
     @abc.abstractmethod
     def get_tools(self) -> List[Tool]:
@@ -49,30 +67,51 @@ class BaseAgent(PackageService, ABC):
         return self.get_agent().run(input=prompt)
 
     @post("answer", public=True)
-    def answer(
-        self, question: str, chat_session_id: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+    def answer(self, **kwargs) -> List[Dict[str, Any]]:
         """Endpoint that implements the contract for Steamship embeddable chat widgets.
         This is a PUBLIC endpoint since these webhooks do not pass a token."""
-        logging.info(f"/answer: {question} {chat_session_id}")
-
         try:
-            response = self.run(question)
+            input_message = self.comms.webtransport_parse(**kwargs)            
+            chain_output = self.run(input_message.text)
+            output_messages = self.chain_output_to_chat_messages(input_message, chain_output)
         except SteamshipError as e:
-            response = [response_for_exception(e)]
+            output_messages = [ChatMessage(
+                client=self.client,
+                chat_id=kwargs.get("chat_session_id"),
+                text=response_for_exception(e)
+            )]
 
-        answer = []
-        for part_response in response if isinstance(response, list) else [response]:
-            if is_valid_uuid(part_response):
-                block = Block.get(self.client, _id=part_response).dict()
-                block["who"] = "bot"
-                answer.append(block)
-            else:
-                answer.append({"message": part_response, "who": "bot"})
-
-        return answer
+        return self.comms.web_transport_send(output_messages)
 
     @post("info")
     def info(self) -> dict:
         """Endpoint returning information about this bot."""
         return {"telegram": "Hello There!"}
+
+    def chain_output_to_chat_messages(self, inbound_message: ChatMessage, chain_output: Union[str, List[str]]) -> List[ChatMessage]:
+        """Transform the output of the Tool/Chain into a list of ChatMessage objects..
+        A tool/chain returns a string or list of strings. The string contents contains a sneak-route for mime encoding:
+        It is either:
+        - A parseable UUID, representing a block containing binary data, or:
+        - Text
+        This method inspects each string and creates a block of the appropriate type.
+        """
+        ret = []
+        for part_response in chain_output if isinstance(chain_output, list) else [chain_output]:
+            if is_valid_uuid(part_response):
+                # It's a block containing binary data.
+                block = Block.get(self.client, _id=part_response).dict()
+                block["who"] = "bot"
+                ret.append(
+                     ChatMessage(client=self.client, chat_id=inbound_message.get_chat_id(), **block)
+                )
+            else:
+                ret.append(
+                    ChatMessage(
+                        client=self.client, 
+                        chat_id=inbound_message.get_chat_id(), 
+                        text=part_response,
+                        who="bot"
+                    )
+                )
+        return ret

--- a/src/core/comms.py
+++ b/src/core/comms.py
@@ -1,0 +1,107 @@
+"""Implements the input/output communication channels for the Agent."""
+from typing import Optional, List, Union
+
+from steamship import Steamship, Block
+from steamship.experimental.transports import TelegramTransport
+from steamship.experimental.transports.chat import ChatMessage
+from steamship.experimental.transports.steamship_widget import SteamshipWidgetTransport
+import logging
+
+class CommsChannels:
+    """
+    Intended usage:
+
+    Inside the Agent __init__:
+
+       self.comms = CommsChannels(..)
+
+    Inside the Agent response function:
+
+       inbound_message = self.comms.XYZ_parse(**kwargs)
+       outbound_result = generate_response(inbound_message)
+       outbound_messages = self.comms.XYZ_send(output)
+       return outbound_messages
+
+    """
+    client: Steamship
+    telegram_token: Optional[str]
+
+    web_transport: SteamshipWidgetTransport
+    telegram_transport: TelegramTransport
+    has_done_runtime_init: bool
+
+    def __init__(
+        self,
+        client: Steamship,
+        telegram_token: Optional[str] = None,
+    ):
+        self.client = client
+        self.telegram_token = telegram_token
+        self.has_done_runtime_init = False
+
+    def runtime_init(self):
+        """Called from within method invocation so that the Exception can be caught in a more convenient place."""
+        self.web_transport = SteamshipWidgetTransport()
+        try:
+            self.telegram_transport = TelegramTransport(bot_token=self.telegram_token)
+        except Exception as ex:
+            logging.error(ex)
+        self.has_done_runtime_init = True
+
+    def telegram_info(self) -> dict:
+        """Endpoint returning information about this bot."""
+        if not self.has_done_runtime_init:
+            self.runtime_init()
+
+        try:
+            return self.telegram_transport.info()
+        except Exception as ex:
+            logging.error(ex)
+            return {}
+
+    def telegram_parse(self, **kwargs) -> Optional[ChatMessage]:
+        """Parses an inbound Telegram message."""
+        if not self.has_done_runtime_init:
+            self.runtime_init()
+
+        if not kwargs or "message" not in kwargs:
+            return None
+        return self.telegram_transport.parse_inbound(payload=kwargs["message"])
+
+    def webtransport_parse(self, **kwargs) -> Optional[ChatMessage]:
+        """Parses an inbound Telegram message."""
+        if not self.has_done_runtime_init:
+            self.runtime_init()
+
+        if not kwargs or "question" not in kwargs:
+            return None
+
+        return self.web_transport.parse_inbound(payload={
+            "question": kwargs.get("question"),
+            "chat_session_id": kwargs.get("chat_session_id")
+        })
+
+    def telegram_send(self, messages: List[ChatMessage]) -> List[dict]:
+        """Send a list of responses to the Telegram user."""
+        if not self.has_done_runtime_init:
+            self.runtime_init()
+
+        if messages:
+            logging.info(f"Sending messages to telegram: {messages}")
+            self.telegram_transport.send(messages)
+        return []
+
+    def web_transport_send(self, messages: List[ChatMessage]) -> List[dict]:
+        """Prepares a list of messages for the Web client."""
+
+        if not self.has_done_runtime_init:
+            self.runtime_init()
+
+        ret = []
+        if messages:
+            logging.info(f"Sending blocks to web client: {messages}")
+            for message in messages:
+                m = message.dict()
+                m["who"] = "bot"
+                ret.append(m)
+        return ret

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,7 +23,7 @@ def is_valid_uuid(uuid_to_test: str, version=4) -> bool:
 
 
 def show_result(client: Steamship, result: str):
-    maybe_block_id = UUID_PATTERN.search(result)
+    maybe_block_id = UUID_PATTERN.search(result or "")
     if maybe_block_id:
         print(f"LLM response ('{result}') contained an image: ", end="")
         signed_url = _make_image_public(client, maybe_block_id.group())

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
-	"handle": "ted-testaa-bot",
-	"version": "0.0.1-rc.3",
+	"handle": "",
+	"version": "0.0.1",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
-	"handle": "",
-	"version": "0.0.1-rc.1",
+	"handle": "ted-testaa-bot",
+	"version": "0.0.1-rc.3",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",
@@ -14,6 +14,11 @@
 		]
 	},
 	"configTemplate": {
+		"telegram_token": {
+			"type": "string",
+			"description": "The secret token for your Telegram bot",
+			"default": ""
+		}
 	},
 	"steamshipRegistry": {
 		"tagline": "",


### PR DESCRIPTION
This adds:

- Transport-style support for Web Client, which doesn't change functionality, but makes it easier to add Telegram and others downstream
- A VS Code Run profile for easy running in VSCode
- A small change to main.py for easy debugging of the agent as a PackageService endpoint